### PR TITLE
Docs: Add Appier

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Collecting the companies using GraphQL.
 - [Sligrid](https://sligrid.com/)
 - [Tagtoo](https://www.tagtoo.com.tw)
 - [Canner](https://www.canner.io)
+- [Appier](https://appier.com)
 
 ## Contributing
 


### PR DESCRIPTION
Thanks for putting up this great repo! Please add us to the list :pray:

Appier uses GraphQL for new projects starting from 2016.

Ref: https://github.com/graphql/graphql.github.io/pull/181